### PR TITLE
updating link to jsperf tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Promises/A+ library.
 - Cross-Browser, Node.js and RequireJS ready.
 - Small.
 - Simple.
-- [Ultra Fast](http://jsperf.com/wqfwewefewrw/9).
+- [Ultra Fast](http://jsperf.com/wqfwewefewrw/28).
 
 ##API
 


### PR DESCRIPTION
Was unable to run the jsperf tests (noticed a 404 on the Q include so they all failed) and found there was an updated test revision - but the link on npmjs.org & this file weren't reflecting the latest.
